### PR TITLE
Add ability to save token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37', 'py38', 'py39']
 verbose = 1
+line-length = 79
 force-exclude = '''
 (
     asv/env

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ install_requires =
 include_package_data = True
 zip_safe = False
 
+[options.entry_points]
+console_scripts =
+    hello-world = tehom:__main__
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ zip_safe = False
 
 [options.entry_points]
 console_scripts =
-    hello-world = tehom:__main__
+    tehom = tehom:__main__
 
 [versioneer]
 VCS = git

--- a/tehom/__init__.py
+++ b/tehom/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import argparse
 
 from typing import Union
@@ -36,3 +37,14 @@ save_token_parser = argparse.ArgumentParser(
 )
 save_token_parser.add_argument("token")
 save_token_parser.add_argument("-f", "--force", type=bool, default=False)
+
+
+def __main__():
+    subcommand = sys.argv[1]
+    if subcommand == "save-token":
+        parser = save_token_parser
+        args = parser.parse_args(sys.argv[2:])
+        subcommand = save_user_token
+    else:
+        raise ValueError(f"No subcommand named '{subcommand}'")
+    subcommand(**vars(args))

--- a/tehom/__init__.py
+++ b/tehom/__init__.py
@@ -1,4 +1,38 @@
+import argparse
+
+from typing import Union
+from pathlib import Path
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions
+
+
+def save_user_token(token: Union[Path, str], force: bool = False) -> None:
+    """Save the provided ONC token so future functions that require an
+    ONC token will use this value by default.
+
+    Arguments:
+        token: the token string or location of the file.  If a file, the
+            first line must contain the token and nothing else.
+        force: whether to overwrite saved token if it exists
+    """
+    save_location = Path(__file__).parent / "token"
+    if save_location.exists() and not force:
+        raise OSError(
+            "A saved token already exists.  If you want to"
+            + "overwrite, pass `force=True`."
+        )
+    if Path(token).exists():
+        with open(Path(token), "r") as fh:
+            token = fh.readline()
+    with open(save_location, "w") as fh:
+        fh.write(token)
+
+
+save_token_parser = argparse.ArgumentParser(
+    description=save_user_token.__doc__
+)
+save_token_parser.add_argument("token")
+save_token_parser.add_argument("-f", "--force", type=bool, default=False)

--- a/tehom/__init__.py
+++ b/tehom/__init__.py
@@ -1,35 +1,11 @@
 import sys
 import argparse
 
-from typing import Union
-from pathlib import Path
-
 from ._version import get_versions
+from ._persistence import save_user_token
 
 __version__ = get_versions()["version"]
 del get_versions
-
-
-def save_user_token(token: Union[Path, str], force: bool = False) -> None:
-    """Save the provided ONC token so future functions that require an
-    ONC token will use this value by default.
-
-    Arguments:
-        token: the token string or location of the file.  If a file, the
-            first line must contain the token and nothing else.
-        force: whether to overwrite saved token if it exists
-    """
-    save_location = Path(__file__).parent / "token"
-    if save_location.exists() and not force:
-        raise OSError(
-            "A saved token already exists.  If you want to"
-            + "overwrite, pass `force=True`."
-        )
-    if Path(token).exists():
-        with open(Path(token), "r") as fh:
-            token = fh.readline()
-    with open(save_location, "w") as fh:
-        fh.write(token)
 
 
 save_token_parser = argparse.ArgumentParser(

--- a/tehom/__main__.py
+++ b/tehom/__main__.py
@@ -1,0 +1,11 @@
+import sys
+
+from . import save_user_token, save_token_parser
+
+
+def __main__():
+    subcommand = sys.argv[1]
+    if subcommand == "save_token":
+        parser = save_token_parser
+        args = parser.parse_args(sys.argv[2:])
+        save_user_token(**vars(args))

--- a/tehom/__main__.py
+++ b/tehom/__main__.py
@@ -1,11 +1,3 @@
-import sys
+from . import __main__
 
-from . import save_user_token, save_token_parser
-
-
-def __main__():
-    subcommand = sys.argv[1]
-    if subcommand == "save_token":
-        parser = save_token_parser
-        args = parser.parse_args(sys.argv[2:])
-        save_user_token(**vars(args))
+__main__()

--- a/tehom/_persistence.py
+++ b/tehom/_persistence.py
@@ -1,4 +1,5 @@
 """Common variables and functions that may be imported by any module"""
+from contextlib import contextmanager
 from typing import Union
 from pathlib import Path
 
@@ -8,6 +9,39 @@ ONC_DB = STORAGE / "onc.db"
 ONC_DIR = STORAGE / "onc"
 AIS_TEMP_DIR = STORAGE / "onc"
 LOCAL_TOKEN_PATH = STORAGE / "token"
+
+
+@contextmanager
+def test_storage():
+    global STORAGE
+    global AIS_DB
+    global ONC_DB
+    global ONC_DIR
+    global AIS_TEMP_DIR
+    global LOCAL_TOKEN_PATH
+
+    temp_storage = STORAGE
+    temp_ais_db = AIS_DB
+    temp_onc_db = ONC_DB
+    temp_onc_dir = ONC_DIR
+    temp_ais_temp_dir = AIS_TEMP_DIR
+    temp_token_path = LOCAL_TOKEN_PATH
+
+    STORAGE = Path(__file__).parent / "test_storage"
+    AIS_DB = STORAGE / "ais.db"
+    ONC_DB = STORAGE / "onc.db"
+    ONC_DIR = STORAGE / "onc"
+    AIS_TEMP_DIR = STORAGE / "onc"
+    LOCAL_TOKEN_PATH = STORAGE / "token"
+
+    yield None
+
+    STORAGE = temp_storage
+    AIS_DB = temp_ais_db
+    ONC_DB = temp_onc_db
+    ONC_DIR = temp_onc_dir
+    AIS_TEMP_DIR = temp_ais_temp_dir
+    LOCAL_TOKEN_PATH = temp_token_path
 
 
 def _init_data_folder():

--- a/tehom/_persistence.py
+++ b/tehom/_persistence.py
@@ -2,11 +2,12 @@
 from typing import Union
 from pathlib import Path
 
-STORAGE = Path(__file__) / "storage"
+STORAGE = Path(__file__).parent / "storage"
 AIS_DB = STORAGE / "ais.db"
 ONC_DB = STORAGE / "onc.db"
 ONC_DIR = STORAGE / "onc"
 AIS_TEMP_DIR = STORAGE / "onc"
+LOCAL_TOKEN_PATH = STORAGE / "token"
 
 
 def _init_data_folder():
@@ -33,3 +34,30 @@ def _init_onc_db(onc_db: Union[Path, str]) -> None:
     #    files: hydrophone, start, duration, format, filename
     #    deployments: mimics return columns of onc.getDeployments()
     pass
+
+
+def save_user_token(token: Union[Path, str], force: bool = False) -> None:
+    """Save the provided ONC token so future functions that require an
+    ONC token will use this value by default.
+
+    Arguments:
+        token: the token string or location of the file.  If a file, the
+            first line must contain the token and nothing else.
+        force: whether to overwrite saved token if it exists
+    """
+    if LOCAL_TOKEN_PATH.exists() and not force:
+        raise OSError(
+            "A saved token already exists.  If you want to"
+            + "overwrite, pass `force=True`."
+        )
+    if Path(token).exists():
+        with open(Path(token), "r") as fh:
+            token = fh.readline()
+    with open(LOCAL_TOKEN_PATH, "w") as fh:
+        fh.write(token)
+
+
+def load_user_token() -> str:
+    """Load saved token"""
+    with open(LOCAL_TOKEN_PATH, "r") as fh:
+        return fh.readline()

--- a/tehom/_persistence.py
+++ b/tehom/_persistence.py
@@ -46,17 +46,17 @@ def test_storage():
 
 def _init_data_folder():
     """Initializes the data folder if it doesn't exist."""
-    if not STORAGE.exists() and STORAGE.is_dir():
+    if not STORAGE.exists():
         STORAGE.mkdir()
-    elif STORAGE.exists() and not STORAGE.is_dir():
+    elif not STORAGE.is_dir():
         raise OSError("{} exists but is not a directory.".format(str(STORAGE)))
-    if not ONC_DIR.exists() and ONC_DIR.is_dir():
+    if not ONC_DIR.exists():
         ONC_DIR.mkdir()
-    elif ONC_DIR.exists() and not ONC_DIR.is_dir():
+    elif not ONC_DIR.is_dir():
         raise OSError("{} exists but is not a directory.".format(str(ONC_DIR)))
-    if not AIS_TEMP_DIR.exists() and AIS_TEMP_DIR.is_dir():
+    if not AIS_TEMP_DIR.exists():
         AIS_TEMP_DIR.mkdir()
-    elif AIS_TEMP_DIR.exists() and not AIS_TEMP_DIR.is_dir():
+    elif not AIS_TEMP_DIR.is_dir():
         raise OSError(f"{AIS_TEMP_DIR} exists but is not a directory.")
     pass
 

--- a/tehom/tests/conftest.py
+++ b/tehom/tests/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 
-from tehom._persistence import test_storage
+from tehom import _persistence
 
 
 @pytest.fixture
 def declare_stateful():
-    with test_storage():
+    with _persistence.test_storage():
+        _persistence._init_data_folder()
         yield None

--- a/tehom/tests/conftest.py
+++ b/tehom/tests/conftest.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 from tehom import _persistence
@@ -6,5 +8,8 @@ from tehom import _persistence
 @pytest.fixture
 def declare_stateful():
     with _persistence.test_storage():
+        if _persistence.STORAGE.exists():
+            shutil.rmtree(_persistence.STORAGE)
         _persistence._init_data_folder()
         yield None
+        shutil.rmtree(_persistence.STORAGE)

--- a/tehom/tests/conftest.py
+++ b/tehom/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from tehom._persistence import test_storage
+
+
+@pytest.fixture
+def declare_stateful():
+    with test_storage():
+        yield None

--- a/tehom/tests/test_basic.py
+++ b/tehom/tests/test_basic.py
@@ -1,2 +1,0 @@
-def test_basic():
-    assert 1 == 1

--- a/tehom/tests/test_persistence.py
+++ b/tehom/tests/test_persistence.py
@@ -1,0 +1,18 @@
+from tehom import _persistence
+
+
+def test_stateful_switch(declare_stateful):
+    temp_path = _persistence.STORAGE
+
+    result = temp_path.stem
+    expected = "test_storage"
+
+    assert result == expected
+
+
+def test_save_token(declare_stateful):
+    expected = "hahaha"
+    _persistence.save_user_token(expected)
+    result = _persistence.load_user_token()
+
+    assert result == expected


### PR DESCRIPTION
This PR allows you to save the ONC token using 
`tehom save-token <token string>`
and retrieve it using (within python) `tehom._persistence.load_user_token()`