### PR TITLE
Fix failing imports of downloads.py

### DIFF
--- a/tehom/downloads.py
+++ b/tehom/downloads.py
@@ -12,6 +12,7 @@ With the datalib, you can:
 * Sample downloaded data into a labeled format, ready for ``model.fit``
 """
 import shutil
+import warnings
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -33,11 +34,16 @@ from onc.onc import ONC
 from . import _persistence
 
 ais_site = "https://coast.noaa.gov/htdata/CMSP/AISDataHandler/"
-onc = ONC(
-    _persistence.load_user_token(),
-    showInfo=True,
-    outPath=str(_persistence.ONC_DIR),
-)
+try:
+    onc = ONC(
+        _persistence.load_user_token(),
+        showInfo=True,
+        outPath=str(_persistence.ONC_DIR),
+    )
+except FileNotFoundError:
+    warnings.warn(
+        "Module loaded with no ONC token; unable to query ONC server data."
+    )
 
 
 def download_ships(year: int, month: int, zone: int) -> None:

--- a/tehom/downloads.py
+++ b/tehom/downloads.py
@@ -576,7 +576,7 @@ def _ais_labeler(
     pass
 
 
-def _truncate_equal_shapes(ser: pd.Series[np.ndarray]) -> pd.Series:
+def _truncate_equal_shapes(ser: pd.Series) -> pd.Series:
     """Truncate most of the data arrays and reject the others
 
     Using an outlier criterion for thresholding, reject all arrays of a


### PR DESCRIPTION
Downloads module tries to load user token upon import.  If it fails
(e.g. on the CI server, which has no token), it no longer raises
an error.